### PR TITLE
Dockerize for homelab deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+
+node_modules
+dist
+
+# Logs / caches / IDE / OS
+*.log
+.eslintcache
+coverage
+.DS_Store
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Stage 1: Build the Quasar SPA
+FROM node:14-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npx quasar build
+
+# Stage 2: Serve with nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist/spa/ /usr/share/nginx/html/
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 RUN npm install
 
 COPY . .
-RUN npx quasar build
+RUN npx --no-install quasar build
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  blog-frontend:
+    build: .
+    container_name: blog-frontend
+    ports:
+      - "5080:80"
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import store from "src/store";
 
-const baseURL = "https://analycube.com:8001"; //8002 dev, 8001 prod
+const baseURL = "/api"; //proxied through nginx
 
 var api;
 axios.defaults.withCredentials = true;

--- a/src/components/post/Comments.vue
+++ b/src/components/post/Comments.vue
@@ -69,7 +69,7 @@ export default {
     },
     computed: {
         commentCount() {
-            return this.list.length ?? null;
+            return this.list.length || null;
         },
         ...mapState(["isLoggedIn", "user"])
     },

--- a/src/pages/Collection.vue
+++ b/src/pages/Collection.vue
@@ -48,7 +48,7 @@ export default {
     },
     meta() {
         return {
-            title: this.collection.title ?? null
+            title: this.collection.title || null
         };
     },
     data() {


### PR DESCRIPTION
## Summary
- Add `Dockerfile` (multi-stage: Node 14 builder → nginx:alpine), `docker-compose.yml` (port 5080→80), and `nginx.conf` with SPA fallback for homelab deploy.
- Point axios `baseURL` at `/api` so the SPA reaches the backend through the homelab gateway nginx (path-based routing via Cloudflare Tunnel) instead of the hardcoded VPS URL `https://analycube.com:8001`.
- Two `??` → `||` swaps in `Comments.vue` and `Collection.vue` to keep the older homelab Babel preset from choking on nullish-coalescing.

## Context
Part of the Vultr VPS → homelab migration. Blog is now live at `blog.legendword.com` via Cloudflare Tunnel.

## Test plan
- [x] `docker compose up -d --build` produces a working frontend container on :5080
- [x] SPA loads at `blog.legendword.com`, posts render, login/comment paths exercised